### PR TITLE
Added most of the common Swift keywords

### DIFF
--- a/Sources/Languages/SwiftLexer.swift
+++ b/Sources/Languages/SwiftLexer.swift
@@ -30,7 +30,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\.\\w+", tokenType: .identifier))
 		
-		let keywords = "class protocol init required public internal import private nil super var let func override deinit return true false enum case if else in guard self weak static extension throws".components(separatedBy: " ")
+		let keywords = "as associatedtype break case catch class continue convenience default defer deinit else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
 		
 		generators.append(keywordGenerator(keywords, tokenType: .keyword))
 		

--- a/Sources/Languages/SwiftLexer.swift
+++ b/Sources/Languages/SwiftLexer.swift
@@ -48,7 +48,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		generators.append(regexGenerator("(\"|@\")[^\"\\n]*(@\"|\")", tokenType: .string))
 		
 		// Multi-line string literal
-		generators.append(regexGenerator("(\"\"\")(.*)(\"\"\")", options: [.dotMatchesLineSeparators], tokenType: .string))
+		generators.append(regexGenerator("(\"\"\")(.*?)(\"\"\")", options: [.dotMatchesLineSeparators], tokenType: .string))
 
 		// Editor placeholder
 		var editorPlaceholderPattern = "(<#)[^\"\\n]*"


### PR DESCRIPTION
Some work needs to be done to recognize `as?`, `as!`, `try?` and `try!`. This also resolves a bug with multi-line strings, where multiple multi-line strings would be read as a single string.