### PR TITLE
Improved the number regex

### DIFF
--- a/Sources/Languages/SwiftLexer.swift
+++ b/Sources/Languages/SwiftLexer.swift
@@ -26,7 +26,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\b(println|print)(?=\\()", tokenType: .identifier))
 		
-		generators.append(regexGenerator("(?<=\\s)\\d+", tokenType: .number))
+		generators.append(regexGenerator("(?<=(\\s|\\[|,|:))\\d+", tokenType: .number))
 		
 		generators.append(regexGenerator("\\.\\w+", tokenType: .identifier))
 		


### PR DESCRIPTION
It now matches the first number in arrays, e.g. `let numbers = [1, 2, 3]` will now correctly match the 1. I've also made it match numbers that are preceded by commas or colons, because some people prefer to write arrays and dictionaries with fewer spaces. 

Note: even this improved regex still doesn't work with floating-point numbers: `let score = 36.2` will still highlight incorrectly.