### PR TITLE
Update SwiftLexer.swift

### DIFF
--- a/Sources/Languages/SwiftLexer.swift
+++ b/Sources/Languages/SwiftLexer.swift
@@ -26,9 +26,9 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\b(println|print)(?=\\()", tokenType: .identifier))
 		
-		generators.append(regexGenerator("(?<=(\\s|\\[|,|:))\\d+", tokenType: .number))
+		generators.append(regexGenerator("(?<=(\\s|\\[|,|:))(\\d|\\.|_)+", tokenType: .number))
 		
-		generators.append(regexGenerator("\\.\\w+", tokenType: .identifier))
+		generators.append(regexGenerator("\\.[A-Za-z_]+\\w*", tokenType: .identifier))
 		
 		let keywords = "as associatedtype break case catch class continue convenience default defer deinit else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
 		


### PR DESCRIPTION
This adds support for floating-point numbers like 3.2, plus integers formatted with underscores such as 1_000_000. I've modified the identifier line because broadly properties and methods can't start with a number, and that's the thing this line is most likely to catch.